### PR TITLE
Update parsing to support the new 'traceItems' format

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Generates simulations from APM parser output
 ## How to use
 
 Build project
+
 ```
 yarn install && yarn run build
 ```
@@ -14,12 +15,13 @@ Put json files from APM parser (each json file should contain requests for a sin
 Run script:
 
 ```
-node scripts/generate_simulations.js --dir ./sample --packageName org.kibanaLoadTest
+node scripts/generate_simulations.js --dir ./sample --packageName org.kibanaLoadTest --url "http://localhost:5620"
 ```
 
 Check `output` directory for .scala files.
 
 Generated simulation example:
+
 ```
 package org.kibanaLoadTest
 
@@ -31,7 +33,7 @@ import io.gatling.jdbc.Predef._
 
 class SampleJourneyName extends Simulation {
   val httpProtocol = http
-    .baseUrl("https://kibana-ops-e2e-perf.kb.us-central1.gcp.cloud.es.io/")
+    .baseUrl("http://localhost:5620")
     .inferHtmlResources()
     .acceptHeader("*/*")
     .acceptEncodingHeader("gzip, deflate")
@@ -61,4 +63,3 @@ class SampleJourneyName extends Simulation {
 }
 
 ```
-

--- a/gatling_template/exec_auth
+++ b/gatling_template/exec_auth
@@ -1,7 +1,7 @@
     .exec(
       http("${path}")
         .post("${path}")
-        .body(StringBody(${payload}))
+        .body(StringBody("${payload}"))
         .asJson
         .headers(${headers})
         .check(headerRegex("set-cookie", ".+?(?=;)").saveAs("Cookie"))

--- a/gatling_template/exec_http_body
+++ b/gatling_template/exec_http_body
@@ -1,7 +1,7 @@
     .exec(
       http("${path}")
         .post("${path}")
-        .body(StringBody(${payload}))
+        .body(StringBody("${payload}"))
         .asJson
         .headers(${headers})
     )

--- a/sample/test.json
+++ b/sample/test.json
@@ -1,9 +1,7 @@
 {
     "journeyName": "Sample Journey Name",
-    "journeyTime": 300000,
-    "kibanaVersion": "v7.17.1",
-    "kibanaUrl": "http:localhost:5260",
-    "maxUsersCount": 1,
+    "kibanaVersion": "8.3.0",
+    "maxUsersCount": "299",
     "traceItems":
     [
         {

--- a/src/lib/buildSimulation.ts
+++ b/src/lib/buildSimulation.ts
@@ -19,7 +19,7 @@ const buildScenario = (scenarioName: string, requests: ReadonlyArray<Request>, t
         const templateStr = getExec(templates, req);
         const templateArgs = !req.body
             ? { path: req.path, method, headers: buildHeaders(req.headers) }
-            : { path: req.path, method, headers: buildHeaders(req.headers), payload: JSON.stringify(req.body) }
+            : { path: req.path, method, headers: buildHeaders(req.headers), payload: JSON.stringify(req.body).replace(/"/g, "\\\"") }
         // construct Gatling exec http calls 
         const exec = template(templateStr, templateArgs);
         // add delay before next request

--- a/src/lib/generateSimulationFile.ts
+++ b/src/lib/generateSimulationFile.ts
@@ -3,7 +3,7 @@ import path from 'path';
 
 import { buildSimulation } from './buildSimulation';
 import { cli } from './cli';
-import {parseTraces} from './parseTraces';
+import { getHttpRequests } from './parseTraces';
 import { Journey } from './types/journey';
 import { Request } from './types/simulation';
 
@@ -28,7 +28,8 @@ export const generateSimulations = () => {
 
     jsonInDir.forEach(file => {
         const journey: Journey = JSON.parse(fs.readFileSync(path.resolve(dir, file)).toString());
-        const requests = parseTraces(journey.traceItems.filter(tr => tr.transactionType === 'request'));
+        // const requests = parseTraces(journey.traceItems.filter(tr => tr.transactionType === 'request'));
+        const requests = getHttpRequests(journey.traceItems);
 
         if (logs) {
             requests.forEach(req => console.log(`${req.date} ${req.transactionId} ${req.method} ${req.path}`))

--- a/src/lib/generateSimulationFile.ts
+++ b/src/lib/generateSimulationFile.ts
@@ -17,7 +17,7 @@ export type SimulationParams = {
 }
 
 export const generateSimulations = () => {
-    const { dir, logs, packageName, errMessage } = cli();
+    const { baseUrl, dir, logs, packageName, errMessage } = cli();
 
     if (errMessage) {
         return console.error(`Error: ${errMessage}`);
@@ -44,7 +44,7 @@ export const generateSimulations = () => {
             simulationName,
             packageName,
             scenarioName: `${journey.journeyName} ${journey.kibanaVersion}`,
-            baseUrl: journey.kibanaUrl,
+            baseUrl: `${baseUrl.protocol}//${baseUrl.host}`,
             maxUsersCount: journey.maxUsersCount,
             requests: requests
         });

--- a/src/lib/parseTraces.ts
+++ b/src/lib/parseTraces.ts
@@ -4,11 +4,25 @@
 /* eslint-disable prefer-const */
 /* eslint functional/prefer-readonly-type: 0 */
 
-import { Trace, Transaction } from './types/journey';
+import { Trace, TraceItem, Transaction } from './types/journey';
 import { Request } from './types/simulation';
 
 const methodRegEx = /GET|POST|PUT|DELETE|UPDATE/g;
 const isValidHttpTrace = (trace: Trace) => trace?.url_path?.length > 1 && trace.http?.request?.headers && trace.http?.request?.method?.match(methodRegEx);
+
+export const getHttpRequests = (traces: ReadonlyArray<TraceItem>): Array<Request> => {
+    return traces.map(trace => {
+        const timestamp = new Date(trace.timestamp).getTime();
+        const date = trace.timestamp;
+        const transactionId = trace.transaction.id;
+        const method = trace.request.method || '';
+        const path = trace.request.url.path;
+        const _headers = trace.request.headers || {};
+        const headers = Object.keys(_headers).map(key => ({ name: key, value: String(_headers[key].join('')) }));
+        const body = trace.request.body
+        return { timestamp, date, transactionId, method, path, headers, body }
+    }).sort((a, b) => a.timestamp > b.timestamp ? 1 : -1);
+}
 
 export const parseTraces = (transactions:Array<Transaction>): Array<Request> => {
     let httpTraces = new Array<Trace>();

--- a/src/lib/types/journey.ts
+++ b/src/lib/types/journey.ts
@@ -1,11 +1,11 @@
-import {Http} from './http';
+import { Http } from './http';
 
 export type Journey = {
     readonly journeyName: string,
     readonly kibanaUrl: string,
     readonly kibanaVersion: string,
     readonly maxUsersCount: number,
-    readonly traceItems: ReadonlyArray<Transaction>,
+    readonly traceItems: ReadonlyArray<TraceItem>,
 }
 
 export type Transaction = {
@@ -24,4 +24,32 @@ export type Trace = {
     readonly http?: Http,
     // eslint-disable-next-line functional/prefer-readonly-type
     readonly children?: Array<Trace>,
+}
+export type Headers = {
+    readonly [key: string]: ReadonlyArray<string>;
+}
+
+export type Request = {
+    readonly url: {
+        readonly path: string;
+    },
+    readonly headers: Headers;
+    readonly method: string;
+    readonly body?: string;
+}
+
+export type TransactionItem = {
+    readonly id: string;
+    readonly name: string;
+    readonly type: string;
+}
+
+export type TraceItem = {
+    readonly traceId: string;
+    readonly timestamp: string;
+    readonly request: Request;
+    readonly response: {
+        readonly status: string;
+    }
+    readonly transaction: TransactionItem; 
 }

--- a/src/lib/types/journey.ts
+++ b/src/lib/types/journey.ts
@@ -2,7 +2,6 @@ import { Http } from './http';
 
 export type Journey = {
     readonly journeyName: string,
-    readonly kibanaUrl: string,
     readonly kibanaVersion: string,
     readonly maxUsersCount: number,
     readonly traceItems: ReadonlyArray<TraceItem>,

--- a/yarn.lock
+++ b/yarn.lock
@@ -206,11 +206,6 @@
     "@babel/helper-validator-identifier" "^7.16.7"
     to-fast-properties "^2.0.0"
 
-"@bitauth/libauth@^1.17.1":
-  version "1.19.1"
-  resolved "https://registry.npmjs.org/@bitauth/libauth/-/libauth-1.19.1.tgz"
-  integrity sha512-R524tD5VwOt3QRHr7N518nqTVR/HKgfWL4LypekcGuNQN8R4PWScvuRcRzrY39A28kLztMv+TJdiKuMNbkU1ug==
-
 "@commitlint/config-validator@^16.2.1":
   version "16.2.1"
   resolved "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-16.2.1.tgz"


### PR DESCRIPTION
With elastic/apm-parser/pull/4 trace items format has been changed again and it breaks generator.

This PR fixes parsing and generator provides valid scala simulation file